### PR TITLE
Fixed icon and UI on HiDPi-enabled devices.

### DIFF
--- a/main/App.config
+++ b/main/App.config
@@ -3,4 +3,7 @@
     <startup> 
         <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
     </startup>
+	<System.Windows.Forms.ApplicationConfigurationSection>
+		<add key="DpiAwareness" value="PerMonitorV2" />
+	</System.Windows.Forms.ApplicationConfigurationSection>
 </configuration>

--- a/main/Forms/frmGroup.cs
+++ b/main/Forms/frmGroup.cs
@@ -107,7 +107,7 @@ namespace client.Forms
         private void frmGroup_Load(object sender, EventArgs e)
         {
             // Scaling form (WORK IN PROGRESS)
-            this.MaximumSize = new Size(605, Screen.PrimaryScreen.WorkingArea.Height);
+            this.MaximumSize = new Size(Size.Width, Screen.PrimaryScreen.WorkingArea.Height);
         }
 
         //--------------------------------------
@@ -130,10 +130,10 @@ namespace client.Forms
 
             if (pnlShortcuts.Controls.Count < 6)
             {
-                pnlShortcuts.Height += 50;
-                pnlAddShortcut.Top += 50;
+                pnlShortcuts.Height += 50 * (int)(frmClient.eDpi / 96);
+                pnlAddShortcut.Top += 50 * (int)(frmClient.eDpi / 96);
             }
-            ucPsc.Location = new Point(25, (pnlShortcuts.Controls.Count * 50)-50);
+            ucPsc.Location = new Point(25 * (int)(frmClient.eDpi / 96), (pnlShortcuts.Controls.Count * 50 * (int)(frmClient.eDpi / 96)) - 50 * (int)(frmClient.eDpi / 96));
             pnlShortcuts.AutoScroll = true;
 
         }
@@ -239,7 +239,7 @@ namespace client.Forms
             {
                 if (before)
                 {
-                    ucPsc.Top -= 50;
+                    ucPsc.Top -= 50 * (int)(frmClient.eDpi / 96);
                     ucPsc.Position -= 1;
                 }
                 if (ucPsc.Shortcut == psc)
@@ -270,8 +270,8 @@ namespace client.Forms
 
             if (pnlShortcuts.Controls.Count < 5)
             {
-                pnlShortcuts.Height -= 50;
-                pnlAddShortcut.Top -= 50;
+                pnlShortcuts.Height -= 50 * (int)(frmClient.eDpi / 96);
+                pnlAddShortcut.Top -= 50 * (int)(frmClient.eDpi / 96);
             }
         }
 
@@ -286,7 +286,7 @@ namespace client.Forms
             // Clears and reloads all shortcuts with new positions
             pnlShortcuts.Controls.Clear();
             pnlShortcuts.Height = 0;
-            pnlAddShortcut.Top = 220;
+            pnlAddShortcut.Top = 220 * (int)(frmClient.eDpi / 96);
 
             selectedShortcut = null;
 

--- a/main/User controls/ucCategoryPanel.cs
+++ b/main/User controls/ucCategoryPanel.cs
@@ -21,8 +21,8 @@ namespace client.User_controls
             picGroupIcon.BackgroundImage = Category.LoadIconImage();
 
             // starting values for position of shortcuts
-            int x = 90;
-            int y = 55;
+            int x = (int)(90 * frmClient.eDpi / 96);
+            int y = (int)(56 * frmClient.eDpi / 96);
             int columns = 1;
 
             if (!Directory.Exists((@"config\" + category.Name) + "\\Icons\\"))
@@ -34,13 +34,13 @@ namespace client.User_controls
             {
                 if (columns == 8)
                 {
-                    x = 90; // resetting x
-                    y += 40; // adding new row
-                    this.Height += 40;
+                    x = (int)(90 * frmClient.eDpi / 96); // resetting x
+                    y += (int)(40 * frmClient.eDpi / 96); // adding new row
+                    this.Height += (int)(40 * frmClient.eDpi / 96);
                     columns = 1;
                 }
                 CreateShortcut(x, y, psc);
-                x += 50;
+                x += (int)(50 * frmClient.eDpi / 96);
                 columns++;
             }
         }
@@ -52,7 +52,7 @@ namespace client.User_controls
             {
                 BackColor = System.Drawing.Color.Transparent,
                 Location = new System.Drawing.Point(x, y),
-                Size = new System.Drawing.Size(30, 30),
+                Size = new System.Drawing.Size((int)(30 * frmClient.eDpi / 96), (int)(30 * frmClient.eDpi / 96)),
                 BackgroundImageLayout = ImageLayout.Stretch,
                 TabStop = false
             };

--- a/main/User controls/ucShortcut.Designer.cs
+++ b/main/User controls/ucShortcut.Designer.cs
@@ -34,6 +34,7 @@
             // 
             // picIcon
             // 
+            this.picIcon.Anchor = System.Windows.Forms.AnchorStyles.None;
             this.picIcon.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
             this.picIcon.Location = new System.Drawing.Point(16, 11);
             this.picIcon.Name = "picIcon";

--- a/main/User controls/ucShortcut.cs
+++ b/main/User controls/ucShortcut.cs
@@ -26,6 +26,7 @@ namespace client.User_controls
 
         private void ucShortcut_Load(object sender, EventArgs e)
         {
+            this.Size = new Size(MotherForm.ucShortcutWidth, MotherForm.ucShortcutHeight);
             this.Show();
             this.BringToFront();
             this.BackColor = MotherForm.BackColor;

--- a/main/client.csproj
+++ b/main/client.csproj
@@ -134,9 +134,11 @@
     </Compile>
     <EmbeddedResource Include="Forms\frmClient.resx">
       <DependentUpon>frmClient.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\frmGroup.resx">
       <DependentUpon>frmGroup.cs</DependentUpon>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
     <EmbeddedResource Include="Forms\frmMain.resx">
       <DependentUpon>frmMain.cs</DependentUpon>


### PR DESCRIPTION
The following pull request fixes the compatibility issues with windows scaling enabled: 

> · Showing the taskbar icons blurred.
> · True-to-size taskbar icon width.
> · Various UI fixes.

**********************

Before :
![client-no-fix](https://user-images.githubusercontent.com/14861890/204934482-8a8a8afe-753d-41f4-8756-53407684dbcd.jpg)
![nofixTB](https://user-images.githubusercontent.com/14861890/204934559-226550de-929d-4419-9ccd-4154894c2884.jpg)

After (on 225% scaling) :
![client](https://user-images.githubusercontent.com/14861890/204934524-75f67bf5-9ec1-42a9-8ab0-a5f38e174b59.jpg)
![TB](https://user-images.githubusercontent.com/14861890/204934569-5062f7a1-e788-4e1e-bbcb-7b2dd8e48b8e.jpg)